### PR TITLE
Update default server port to 40870

### DIFF
--- a/main.go
+++ b/main.go
@@ -71,11 +71,11 @@ func main() {
 	// ストリーム購読開始（無限リトライ）
 	models.Log.Info("Starting stream fetcher...")
 	go db.StartStreamFetcher(ctx, dbConn, streamURL)
-	
+
 	// サービス情報の取得開始
 	models.Log.Info("Starting service fetcher...")
 	go db.StartServiceFetcher(ctx, mirakurunURL)
-	
+
 	// サービスイベントストリームの購読開始
 	models.Log.Info("Starting service event stream...")
 	go db.StartServiceEventStream(ctx, mirakurunURL)
@@ -159,7 +159,7 @@ func main() {
 
 	port := os.Getenv("PORT")
 	if port == "" {
-		port = "8080"
+		port = "40870" // default port when PORT is unset
 	}
 	models.Log.Info("Listening on :%s", port)
 	if err := http.ListenAndServe(":"+port, nil); err != nil {


### PR DESCRIPTION
## Summary
- use `40870` when `PORT` is not set
- log the updated default value on startup

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68409ca07b608323a1cfde58e18bf1e6