### PR TITLE
/program エンドポイントのルーティング問題を修正

### DIFF
--- a/main.go
+++ b/main.go
@@ -137,7 +137,7 @@ func main() {
 		models.Log.Debug("Handling remove excluded service request: %s", r.URL.String())
 		handlers.HandleRemoveExcludedService(w, r, dbConn)
 	})
-	router.HandleFunc("/program/", func(w http.ResponseWriter, r *http.Request) {
+	router.PathPrefix("/program/").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		models.Log.Debug("Handling IEPG request: %s", r.URL.String())
 		handlers.HandleIEPG(w, r, dbConn)
 	})


### PR DESCRIPTION
## 概要
`/program/{id}` および `/program/{id}.tvpid` 形式のURLで404エラーが発生していた問題を修正しました。

## 問題
- `router.HandleFunc("/program/", ...)` は `/program/` で終わるパスのみにマッチ
- `/program/123` や `/program/123.tvpid` のようなパスにはマッチしなかった
- そのため、番組情報取得APIが機能していなかった

## 解決策
`router.PathPrefix("/program/").HandlerFunc(...)` に変更することで、`/program/` で始まるすべてのパスにマッチするようにしました。

## テスト方法
```bash
# 番組を検索
curl "http://localhost:40870/search?q=ニュース"

# 検索結果から番組IDを取得して、番組情報を取得
curl "http://localhost:40870/program/{番組ID}"
```

## 動作確認
修正後、以下のURLで正常にiEPG形式のデータが取得できることを確認しました：
- `http://localhost:40870/program/60034950446`
- `http://localhost:40870/program/60034950446.tvpid`

🤖 Generated with [Claude Code](https://claude.ai/code)