### PR TITLE
fix: フィルタ状態が放送局選択時にリセットされる問題を修正

### DIFF
--- a/handlers/search.go
+++ b/handlers/search.go
@@ -124,6 +124,7 @@ func HandleSimpleSearch(w http.ResponseWriter, r *http.Request, dbConn *sql.DB) 
 }
 
 // HandleGetServices はすべてのサービス情報を返すハンドラー
+// 除外チャンネルを除いたサービス一覧を返す
 func HandleGetServices(w http.ResponseWriter, r *http.Request, dbConn *sql.DB) {
 	models.Log.Debug("HandleGetServices: Processing request from %s", r.RemoteAddr)
 	
@@ -131,6 +132,7 @@ func HandleGetServices(w http.ResponseWriter, r *http.Request, dbConn *sql.DB) {
 	excludedTypes := []int{192}
 	
 	// すべてのサービスを取得（タイプ192および除外チャンネルを除く）
+	// GetFilteredServicesは除外チャンネルも自動的に除外する
 	services := db.GetFilteredServices(dbConn, nil, excludedTypes)
 	
 	// デバッグ: サービスタイプ情報をログに出力

--- a/static/exclude-channels.html
+++ b/static/exclude-channels.html
@@ -172,11 +172,27 @@
         // すべてのデータを読み込む
         async function loadAllData() {
             try {
+                // 現在のフィルタ状態を保存
+                const activeFilter = document.querySelector('.filter-btn.bg-indigo-600')?.dataset.type || 'all';
+                const searchTerm = document.getElementById('channelSearch')?.value || '';
+                
                 await Promise.all([
                     loadChannelList(),
                     loadExcludedList()
                 ]);
                 console.log("すべてのデータを読み込みました");
+                
+                // フィルタ状態を復元
+                if (activeFilter !== 'all') {
+                    const filterBtn = document.querySelector(`.filter-btn[data-type="${activeFilter}"]`);
+                    if (filterBtn) {
+                        filterBtn.click();
+                    }
+                }
+                if (searchTerm) {
+                    document.getElementById('channelSearch').value = searchTerm;
+                    filterChannelsByName(searchTerm);
+                }
             } catch (error) {
                 console.error("データの読み込みに失敗しました:", error);
             }

--- a/static/search.html
+++ b/static/search.html
@@ -262,6 +262,9 @@
                 // サービスセレクトボックスの構築
                 const selectEl = document.getElementById('serviceId');
                 
+                // 現在選択されているサービスIDを保存
+                const currentServiceId = selectEl.value;
+                
                 // サービスを種類ごとにグループ化
                 const serviceGroups = {
                     1: [], // 地上波
@@ -319,6 +322,11 @@
                 
                 console.log(`${services.length}件のサービスを読み込みました`);
                 
+                // 以前選択されていたサービスIDを復元
+                if (currentServiceId && selectEl.querySelector(`option[value="${currentServiceId}"]`)) {
+                    selectEl.value = currentServiceId;
+                }
+                
                 // 放送種別ラジオボタンの変更イベントを設定
                 setupChannelFilterEvents();
                 
@@ -343,6 +351,7 @@
         function filterChannelOptions() {
             const selectedFilter = document.querySelector('input[name="channelFilter"]:checked').value;
             const selectEl = document.getElementById('serviceId');
+            const currentServiceId = selectEl.value; // 現在の選択値を保存
             
             // 「すべて」の場合は全オプショングループを表示
             if (selectedFilter === 'all') {
@@ -350,6 +359,10 @@
                     if (selectEl.children[i].tagName === 'OPTGROUP') {
                         selectEl.children[i].style.display = '';
                     }
+                }
+                // 選択値を復元
+                if (currentServiceId && selectEl.querySelector(`option[value="${currentServiceId}"]`)) {
+                    selectEl.value = currentServiceId;
                 }
                 return;
             }
@@ -376,7 +389,10 @@
                 return optGroup.style.display !== 'none';
             });
             
-            if (visibleOptions.length > 0 && !visibleOptions.includes(selectEl.options[selectEl.selectedIndex])) {
+            // 選択値を復元（可能な場合）
+            if (currentServiceId && visibleOptions.find(opt => opt.value === currentServiceId)) {
+                selectEl.value = currentServiceId;
+            } else if (visibleOptions.length > 0 && !visibleOptions.includes(selectEl.options[selectEl.selectedIndex])) {
                 selectEl.value = visibleOptions[0].value;
             }
         }


### PR DESCRIPTION
## Summary
- 放送局選択時にフィルタ設定（チャンネル除外、BS/CSフィルタ）がリセットされる問題を修正しました
- フィルタを適用した状態で操作を続けられるようになり、UI操作性が向上します

## Changes
- 放送局（サービス）選択時に現在の選択値を保存・復元する処理を追加
- チャンネルフィルター（地上波/BS/CS）変更時も選択値を維持するよう改善
- 除外チャンネルが適切に反映されることを明確化（コメント更新）

## Test plan
- [ ] チャンネル除外設定を行う
- [ ] BSまたはCSフィルタを適用する
- [ ] 放送局を選択する
- [ ] フィルタ設定が維持されていることを確認
- [ ] 選択した放送局が維持されていることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)