### PR TITLE
feat: 録画サーバー設定管理機能を追加

### DIFF
--- a/db/database.go
+++ b/db/database.go
@@ -191,6 +191,21 @@ func InitDB(dataSourceName string) (*sql.DB, error) {
 		models.Log.Error("InitDB: Failed to create index on auto_reservation_logs.ruleId: %v", err)
 	}
 
+	// settingsテーブルの作成
+	_, err = db.Exec(`
+		CREATE TABLE IF NOT EXISTS settings (
+			id            INTEGER PRIMARY KEY,
+			recorder_urls TEXT NOT NULL DEFAULT '[]',
+			created_at    TEXT NOT NULL DEFAULT (datetime('now')),
+			updated_at    TEXT NOT NULL DEFAULT (datetime('now'))
+		);
+	`)
+	if err != nil {
+		models.Log.Error("InitDB: Failed to create settings table: %v", err)
+		db.Close()
+		return nil, err
+	}
+
 	models.Log.Debug("InitDB: Database initialization completed successfully")
 	return db, nil
 }

--- a/handlers/settings.go
+++ b/handlers/settings.go
@@ -1,0 +1,103 @@
+package handlers
+
+import (
+	"database/sql"
+	"encoding/json"
+	"net/http"
+
+	"github.com/fuba/iepg-server/models"
+)
+
+// SettingsHandler handles settings-related requests
+type SettingsHandler struct {
+	db *sql.DB
+}
+
+// NewSettingsHandler creates a new settings handler
+func NewSettingsHandler(db *sql.DB) *SettingsHandler {
+	return &SettingsHandler{db: db}
+}
+
+// GetSettings handles GET /api/settings
+func (h *SettingsHandler) GetSettings(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	settings, err := models.GetSettings(h.db)
+	if err != nil {
+		models.Log.Error("GetSettings: Failed to get settings: %v", err)
+		http.Error(w, "Failed to get settings", http.StatusInternalServerError)
+		return
+	}
+
+	servers, err := settings.GetRecorderServers()
+	if err != nil {
+		models.Log.Error("GetSettings: Failed to parse recorder servers: %v", err)
+		http.Error(w, "Failed to parse recorder servers", http.StatusInternalServerError)
+		return
+	}
+
+	response := map[string]interface{}{
+		"recorderServers": servers,
+	}
+
+	json.NewEncoder(w).Encode(response)
+}
+
+// UpdateRecorderServers handles POST /api/settings/recorder-servers
+func (h *SettingsHandler) UpdateRecorderServers(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	var request struct {
+		RecorderServers []models.RecorderServer `json:"recorderServers"`
+	}
+
+	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+		models.Log.Error("UpdateRecorderServers: Failed to decode request: %v", err)
+		http.Error(w, "Invalid JSON", http.StatusBadRequest)
+		return
+	}
+
+	// Validate servers
+	for i, server := range request.RecorderServers {
+		if server.Name == "" {
+			models.Log.Error("UpdateRecorderServers: Server name is required at index %d", i)
+			http.Error(w, "Server name is required", http.StatusBadRequest)
+			return
+		}
+		if server.URL == "" {
+			models.Log.Error("UpdateRecorderServers: Server URL is required at index %d", i)
+			http.Error(w, "Server URL is required", http.StatusBadRequest)
+			return
+		}
+	}
+
+	settings, err := models.GetSettings(h.db)
+	if err != nil {
+		models.Log.Error("UpdateRecorderServers: Failed to get settings: %v", err)
+		http.Error(w, "Failed to get settings", http.StatusInternalServerError)
+		return
+	}
+
+	err = settings.SetRecorderServers(request.RecorderServers)
+	if err != nil {
+		models.Log.Error("UpdateRecorderServers: Failed to set recorder servers: %v", err)
+		http.Error(w, "Failed to set recorder servers", http.StatusInternalServerError)
+		return
+	}
+
+	err = settings.Save(h.db)
+	if err != nil {
+		models.Log.Error("UpdateRecorderServers: Failed to save settings: %v", err)
+		http.Error(w, "Failed to save settings", http.StatusInternalServerError)
+		return
+	}
+
+	models.Log.Info("Updated recorder servers: %d servers", len(request.RecorderServers))
+
+	response := map[string]interface{}{
+		"success": true,
+		"message": "Recorder servers updated successfully",
+	}
+
+	json.NewEncoder(w).Encode(response)
+}

--- a/main.go
+++ b/main.go
@@ -105,6 +105,9 @@ func main() {
 
 	// 予約ハンドラーの初期化
 	reservationHandler := handlers.NewReservationHandler(dbConn, recorderURL)
+	
+	// 設定ハンドラーの初期化
+	settingsHandler := handlers.NewSettingsHandler(dbConn)
 
 	// 自動予約エンジンの初期化と開始
 	autoReservationEngine := services.NewAutoReservationEngine(dbConn, recorderURL)
@@ -172,6 +175,10 @@ func main() {
 	router.HandleFunc("/auto-reservations/rules/{id}", handlers.HandleDeleteAutoReservationRule(dbConn)).Methods("DELETE")
 	router.HandleFunc("/auto-reservations/logs", handlers.HandleGetAutoReservationLogs(dbConn)).Methods("GET")
 
+	// 設定関連のエンドポイント
+	router.HandleFunc("/api/settings", settingsHandler.GetSettings).Methods("GET")
+	router.HandleFunc("/api/settings/recorder-servers", settingsHandler.UpdateRecorderServers).Methods("POST")
+
 	// 静的ファイルの提供
 	fs := http.FileServer(http.Dir("./static"))
 	router.PathPrefix("/static/").Handler(http.StripPrefix("/static/", fs))
@@ -196,6 +203,12 @@ func main() {
 	router.HandleFunc("/ui/exclude-channels", func(w http.ResponseWriter, r *http.Request) {
 		models.Log.Debug("Serving exclude channels UI")
 		http.ServeFile(w, r, "./static/exclude-channels.html")
+	})
+
+	// 設定UI
+	router.HandleFunc("/ui/settings", func(w http.ResponseWriter, r *http.Request) {
+		models.Log.Debug("Serving settings UI")
+		http.ServeFile(w, r, "./static/settings.html")
 	})
 
 	// 自動予約管理UI

--- a/models/settings.go
+++ b/models/settings.go
@@ -1,0 +1,89 @@
+package models
+
+import (
+	"database/sql"
+	"encoding/json"
+)
+
+// Settings represents user settings
+type Settings struct {
+	ID           int    `json:"id" db:"id"`
+	RecorderURLs string `json:"recorder_urls" db:"recorder_urls"` // JSON array of server URLs
+	CreatedAt    string `json:"created_at" db:"created_at"`
+	UpdatedAt    string `json:"updated_at" db:"updated_at"`
+}
+
+// RecorderServer represents a recorder server configuration
+type RecorderServer struct {
+	Name string `json:"name"`
+	URL  string `json:"url"`
+}
+
+// GetRecorderServers parses the recorder URLs JSON
+func (s *Settings) GetRecorderServers() ([]RecorderServer, error) {
+	if s.RecorderURLs == "" {
+		return []RecorderServer{}, nil
+	}
+	
+	var servers []RecorderServer
+	err := json.Unmarshal([]byte(s.RecorderURLs), &servers)
+	return servers, err
+}
+
+// SetRecorderServers sets the recorder URLs as JSON
+func (s *Settings) SetRecorderServers(servers []RecorderServer) error {
+	data, err := json.Marshal(servers)
+	if err != nil {
+		return err
+	}
+	s.RecorderURLs = string(data)
+	return nil
+}
+
+// GetSettings retrieves or creates user settings
+func GetSettings(db *sql.DB) (*Settings, error) {
+	settings := &Settings{}
+	
+	// Try to get existing settings
+	query := `SELECT id, recorder_urls, created_at, updated_at FROM settings WHERE id = 1`
+	err := db.QueryRow(query).Scan(&settings.ID, &settings.RecorderURLs, &settings.CreatedAt, &settings.UpdatedAt)
+	
+	if err == sql.ErrNoRows {
+		// Create default settings
+		return createDefaultSettings(db)
+	} else if err != nil {
+		return nil, err
+	}
+	
+	return settings, nil
+}
+
+// SaveSettings saves the settings to database
+func (s *Settings) Save(db *sql.DB) error {
+	query := `UPDATE settings SET recorder_urls = ?, updated_at = datetime('now') WHERE id = 1`
+	_, err := db.Exec(query, s.RecorderURLs)
+	return err
+}
+
+// createDefaultSettings creates default settings record
+func createDefaultSettings(db *sql.DB) (*Settings, error) {
+	// Create default recorder servers
+	defaultServers := []RecorderServer{
+		{Name: "Local Server", URL: "http://localhost:37569"},
+	}
+	
+	settings := &Settings{ID: 1}
+	err := settings.SetRecorderServers(defaultServers)
+	if err != nil {
+		return nil, err
+	}
+	
+	query := `INSERT INTO settings (id, recorder_urls, created_at, updated_at) 
+			  VALUES (1, ?, datetime('now'), datetime('now'))`
+	_, err = db.Exec(query, settings.RecorderURLs)
+	if err != nil {
+		return nil, err
+	}
+	
+	return GetSettings(db)
+}

--- a/notes/japanese-search-implementation.md
+++ b/notes/japanese-search-implementation.md
@@ -1,0 +1,336 @@
+# 日本語検索実装の工夫とノウハウ
+
+## 概要
+
+このドキュメントでは、iEPG番組表検索システムにおける日本語検索の実装技術と工夫について詳述します。日本語特有の課題（文字種の多様性、放送業界固有の文字、エンコーディング互換性）に対する包括的なソリューションを提供しています。
+
+## 1. テキスト正規化システム
+
+### 1.1 Unicode正規化 (NFKC)
+**実装場所**: `models/normalizer.go:NormalizeText()`
+
+```go
+// 互換等価文字を正規等価文字に変換
+text = norm.NFKC.String(text)
+```
+
+**効果**:
+- 囲み文字（①→1）、組文字（㍻→平成）の統一
+- 異体字の基本文字への統一
+- 検索時の表記ゆれ解決
+
+### 1.2 全角→半角変換
+```go
+// アルファベット・数字・記号の半角化
+text = width.Narrow.String(text)
+```
+
+**対象文字**:
+- 全角英数字 → 半角英数字
+- 全角記号 → 半角記号（一部）
+- 全角スペース → 半角スペース
+
+### 1.3 大文字→小文字変換
+```go
+text = strings.ToLower(text)
+```
+
+**検索精度向上**: 大文字小文字の違いを無視した検索を実現
+
+### 1.4 空白・改行正規化
+```go
+// 改行を半角スペースに変換
+text = strings.ReplaceAll(text, "\n", " ")
+// 連続する空白を単一スペースに統一
+re := regexp.MustCompile(`\s+`)
+text = re.ReplaceAllString(text, " ")
+```
+
+## 2. ARIB外字対応
+
+### 2.1 放送業界特殊文字
+**実装場所**: `models/aribgaiji.go`
+
+**対応文字一覧**:
+```go
+var aribGaijiMap = map[rune]string{
+    0x7A50: "[HV]",     // ハイビジョン
+    0x7A51: "[SD]",     // 標準画質
+    0x7A52: "[字]",     // 字幕
+    0x7A53: "[双]",     // 二ヶ国語
+    0x7A54: "[再]",     // 再放送
+    0x7A55: "[新]",     // 新番組
+    // ... 32種類の放送用記号
+}
+```
+
+### 2.2 Unicode絵文字マッピング
+```go
+var unicodeEmojiMap = map[rune]string{
+    0x1F21A: "[無]",    // 🈚 無料
+    0x1F22F: "[指]",    // 🈯 指定席
+    0x26C5:  "[曇]",    // ⛅ 曇り
+    // ... 天気記号等の対応
+}
+```
+
+**用途**:
+- 番組表での視覚的表現の統一
+- 検索時の文字一致精度向上
+- レガシーシステムとの互換性確保
+
+## 3. 検索アルゴリズム
+
+### 3.1 AND検索（基本動作）
+**実装場所**: `db/database.go:SearchPrograms()`
+
+```go
+// スペース区切りの全キーワードを必須とする
+keywords := strings.Fields(normalizedQuery)
+for _, keyword := range keywords {
+    if !strings.HasPrefix(keyword, "-") && !isQuoted(keyword) {
+        conditions = append(conditions, 
+            "(p.nameForSearch LIKE ? OR p.descForSearch LIKE ?)")
+        args = append(args, "%"+keyword+"%", "%"+keyword+"%")
+    }
+}
+```
+
+**特徴**:
+- 2025年にOR検索からAND検索に変更
+- より絞り込まれた精度の高い検索結果
+- 複数キーワードでの詳細検索が可能
+
+### 3.2 フレーズ検索
+```go
+// ダブルクォーテーション囲みの語順保持検索
+if strings.HasPrefix(keyword, "\"") && strings.HasSuffix(keyword, "\"") {
+    phrase := strings.Trim(keyword, "\"")
+    conditions = append(conditions, 
+        "(p.nameForSearch LIKE ? OR p.descForSearch LIKE ?)")
+    args = append(args, "%"+phrase+"%", "%"+phrase+"%")
+}
+```
+
+**用途**:
+- 番組タイトルの正確な検索
+- 特定フレーズの語順を重視した検索
+
+### 3.3 否定検索
+```go
+// マイナスプレフィックスで除外検索
+if strings.HasPrefix(keyword, "-") {
+    excludeKeyword := strings.TrimPrefix(keyword, "-")
+    conditions = append(conditions, 
+        "(p.nameForSearch NOT LIKE ? AND p.descForSearch NOT LIKE ?)")
+    args = append(args, "%"+excludeKeyword+"%", "%"+excludeKeyword+"%")
+}
+```
+
+**活用例**:
+- `-ニュース`: ニュース番組を除外
+- `-再放送`: 再放送を除外した新作番組の検索
+
+### 3.4 複合検索
+```
+検索例: "今日のニュース" 政治 -スポーツ
+→ 「今日のニュース」を含み、かつ「政治」を含み、かつ「スポーツ」を含まない番組
+```
+
+## 4. データベース設計
+
+### 4.1 検索最適化スキーマ
+```sql
+CREATE TABLE programs (
+    id INTEGER PRIMARY KEY,
+    name TEXT NOT NULL,           -- 表示用番組名
+    nameForSearch TEXT,           -- 検索用正規化済み番組名
+    description TEXT,             -- 表示用番組説明
+    descForSearch TEXT,           -- 検索用正規化済み番組説明
+    -- その他のフィールド
+);
+```
+
+**設計思想**:
+- 表示用と検索用のフィールド分離
+- 検索処理の高速化（事前正規化）
+- データ整合性の確保
+
+### 4.2 インデックス戦略
+```sql
+CREATE INDEX idx_programs_search ON programs(nameForSearch, descForSearch);
+CREATE INDEX idx_programs_time ON programs(startAt, endAt);
+CREATE INDEX idx_programs_channel ON programs(serviceId);
+```
+
+## 5. エンコーディング処理
+
+### 5.1 iEPG出力のShift-JIS変換
+**実装場所**: `handlers/iepg.go:convertToShiftJIS()`
+
+```go
+func convertToShiftJIS(text string) string {
+    encoder := japanese.ShiftJIS.NewEncoder()
+    encoded, err := encoder.String(text)
+    if err != nil {
+        // エンコードできない文字の代替処理
+        return sanitizeForShiftJIS(text)
+    }
+    return encoded
+}
+```
+
+### 5.2 文字サニタイズ処理
+```go
+func sanitizeForShiftJIS(text string) string {
+    result := make([]rune, 0, len(text))
+    for _, r := range text {
+        switch {
+        case isUnicodeEmoji(r):
+            result = append(result, []rune("[絵文字]")...)
+        case isKanjiOutOfJIS(r):
+            result = append(result, []rune("[漢字]")...)
+        case isSpecialKana(r):
+            result = append(result, []rune("[仮名]")...)
+        default:
+            if !canEncodeToShiftJIS(r) {
+                result = append(result, '・')
+            } else {
+                result = append(result, r)
+            }
+        }
+    }
+    return string(result)
+}
+```
+
+## 6. フロントエンド検索UI
+
+### 6.1 検索構文ガイダンス
+**実装場所**: `static/search.html`
+
+```html
+<div class="search-help">
+    <h4>検索のコツ</h4>
+    <ul>
+        <li><code>ニュース スポーツ</code> - すべてを含む</li>
+        <li><code>"今日のニュース"</code> - 語順通りに含む</li>
+        <li><code>-スポーツ</code> - 含まないものを表示</li>
+        <li><code>"特集番組" 野球 -ニュース</code> - 組み合わせ</li>
+    </ul>
+</div>
+```
+
+### 6.2 日本語対応カレンダー
+```javascript
+// flatpickrによる日本語ローカライゼーション
+flatpickr("#dateRange", {
+    locale: "ja",
+    mode: "range",
+    dateFormat: "Y-m-d",
+    defaultDate: [today, tomorrow]
+});
+```
+
+## 7. パフォーマンス最適化
+
+### 7.1 事前正規化戦略
+- **データ挿入時**: 番組情報取得時に検索用フィールドを正規化
+- **メリット**: 検索時の正規化処理コストを削減
+- **トレードオフ**: ストレージ使用量の微増
+
+### 7.2 除外チャンネル処理
+```go
+// 検索時に除外設定チャンネルを自動フィルタリング
+excludedServices := getExcludedServices()
+if len(excludedServices) > 0 {
+    placeholders := strings.Repeat("?,", len(excludedServices)-1) + "?"
+    conditions = append(conditions, "p.serviceId NOT IN ("+placeholders+")")
+}
+```
+
+## 8. テスト戦略
+
+### 8.1 正規化テスト
+**実装場所**: `models/normalizer_test.go` (想定)
+
+```go
+func TestNormalizeText(t *testing.T) {
+    testCases := []struct {
+        input    string
+        expected string
+    }{
+        {"ニュース　７", "ニュース 7"},              // 全角→半角
+        {"①②③", "123"},                        // 囲み文字
+        {"㍻㍿", "平成株式会社"},                    // 組文字
+        {"\"特集番組\"", "\"特集番組\""},            // クォート保持
+    }
+    
+    for _, tc := range testCases {
+        result := NormalizeText(tc.input)
+        assert.Equal(t, tc.expected, result)
+    }
+}
+```
+
+### 8.2 検索機能テスト
+```go
+func TestSearchPrograms(t *testing.T) {
+    // AND検索テスト
+    results := SearchPrograms("ニュース スポーツ")
+    // 結果に両方のキーワードが含まれることを確認
+    
+    // フレーズ検索テスト  
+    results = SearchPrograms("\"今日のニュース\"")
+    // 語順が保持されることを確認
+    
+    // 否定検索テスト
+    results = SearchPrograms("-再放送")
+    // 再放送が除外されることを確認
+}
+```
+
+## 9. 運用上の考慮事項
+
+### 9.1 文字コード互換性
+- **UTF-8**: 内部処理とAPI通信
+- **Shift-JIS**: iEPG出力（レガシー互換性）
+- **エラーハンドリング**: エンコードできない文字の適切な代替
+
+### 9.2 放送業界標準への準拠
+- **ARIB規格**: 放送用外字の完全サポート
+- **番組表規格**: EPG（電子番組ガイド）標準との互換性
+- **更新対応**: 新しい放送用記号の追加に対する拡張性
+
+### 9.3 パフォーマンス監視
+- **検索レスポンス時間**: 通常100ms以下を目標
+- **データベース負荷**: インデックス効率の定期確認
+- **メモリ使用量**: 正規化処理のメモリ効率監視
+
+## 10. 今後の改善案
+
+### 10.1 形態素解析の導入
+- **MeCab/Kuromoji**: より精密な日本語解析
+- **読み検索**: ひらがな・カタカナでの番組名検索
+- **類義語検索**: シノニム辞書による検索拡張
+
+### 10.2 検索精度向上
+- **TF-IDF**: 文書頻度による関連度スコアリング
+- **ファジー検索**: 誤字脱字に対する寛容な検索
+- **学習機能**: ユーザー検索履歴からの改善
+
+### 10.3 多言語対応
+- **英語番組**: 海外番組の検索対応
+- **韓国語・中国語**: アジア圏番組への対応拡張
+
+## まとめ
+
+このシステムの日本語検索実装は、以下の特徴により高精度で実用的な検索体験を提供しています：
+
+1. **包括的な文字正規化**: Unicode標準に準拠した確実な文字統一
+2. **放送業界特化**: ARIB外字など業界固有要求への完全対応  
+3. **柔軟な検索構文**: AND/フレーズ/否定検索の組み合わせ
+4. **エンコーディング互換性**: モダンなUTF-8とレガシーShift-JISの両立
+5. **パフォーマンス最適化**: 事前正規化による高速検索の実現
+
+これらの技術的工夫により、日本語番組表検索システムとして高い実用性と信頼性を確保しています。

--- a/static/search.html
+++ b/static/search.html
@@ -47,6 +47,9 @@
         <div class="flex justify-between items-center mb-6">
             <h1 class="text-2xl font-bold text-gray-800">番組検索</h1>
             <div class="flex space-x-2">
+                <a href="/ui/settings" class="px-4 py-2 bg-green-500 text-white font-medium rounded-md hover:bg-green-600 focus:outline-none">
+                    設定
+                </a>
                 <a href="/ui/exclude-channels" class="px-4 py-2 bg-gray-200 text-gray-700 font-medium rounded-md hover:bg-gray-300 focus:outline-none">
                     チャンネル除外設定
                 </a>
@@ -230,8 +233,10 @@
                         </div>
                         
                         <div class="mb-3">
-                            <label for="recorderUrl" class="block text-sm font-medium text-gray-700">録画サーバーURL</label>
-                            <input type="url" id="autoRecorderUrl" value="http://localhost:37569" class="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500" required>
+                            <label for="autoRecorderUrl" class="block text-sm font-medium text-gray-700">録画サーバー</label>
+                            <select id="autoRecorderUrl" class="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500" required>
+                                <option value="">読み込み中...</option>
+                            </select>
                         </div>
                         
                         <div class="flex items-center justify-between pt-4">
@@ -243,6 +248,39 @@
                             </button>
                         </div>
                     </form>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- 予約モーダル -->
+    <div id="reservationModal" class="fixed inset-0 bg-gray-600 bg-opacity-50 overflow-y-auto h-full w-full hidden">
+        <div class="relative top-20 mx-auto p-5 border w-96 shadow-lg rounded-md bg-white">
+            <div class="mt-3">
+                <div class="mx-auto flex items-center justify-center h-12 w-12 rounded-full bg-blue-100">
+                    <svg class="h-6 w-6 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"></path>
+                    </svg>
+                </div>
+                <div class="mt-2 text-center">
+                    <h3 class="text-lg leading-6 font-medium text-gray-900" id="reservationModalTitle">番組を予約</h3>
+                    <div class="mt-4">
+                        <div class="mb-3">
+                            <label for="reservationRecorderSelect" class="block text-sm font-medium text-gray-700">録画サーバー</label>
+                            <select id="reservationRecorderSelect" class="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500" required>
+                                <option value="">読み込み中...</option>
+                            </select>
+                        </div>
+                        
+                        <div class="flex items-center justify-between pt-4">
+                            <button type="button" onclick="closeReservationModal()" class="px-4 py-2 bg-gray-300 text-gray-700 text-sm font-medium rounded-md hover:bg-gray-400 focus:outline-none">
+                                キャンセル
+                            </button>
+                            <button type="button" onclick="confirmReservation()" class="px-4 py-2 bg-blue-600 text-white text-sm font-medium rounded-md hover:bg-blue-700 focus:outline-none">
+                                予約
+                            </button>
+                        </div>
+                    </div>
                 </div>
             </div>
         </div>
@@ -629,24 +667,97 @@
                 .replace(/'/g, "&#039;");
         }
         
+        // Global variables for reservation modal
+        let currentReservationData = null;
+
         // ボタンのクリックイベント処理
         document.addEventListener('click', function(e) {
             if (e.target.classList.contains('reservation-btn')) {
                 const programId = e.target.dataset.programId;
                 const programName = e.target.dataset.programName;
                 
-                // 録画サーバーのURLを入力するダイアログ
-                const recorderUrl = prompt('録画サーバーのURLを入力してください\n(例: http://localhost:37569)\n空欄の場合は環境変数で設定されたデフォルトを使用します。', 'http://localhost:37569');
-                
-                if (recorderUrl !== null) { // nullはキャンセルボタンが押された場合
-                    // 予約処理
-                    makeReservation(programId, programName, recorderUrl);
-                }
+                // 予約モーダルを開く
+                openReservationModal(programId, programName);
             } else if (e.target.classList.contains('auto-reservation-btn')) {
                 const programData = JSON.parse(e.target.dataset.program);
                 openAutoReservationModal(programData);
             }
         });
+
+        // 予約モーダルを開く
+        async function openReservationModal(programId, programName) {
+            currentReservationData = { programId, programName };
+            
+            // モーダルタイトルを設定
+            document.getElementById('reservationModalTitle').textContent = `${programName} を予約`;
+            
+            // 録画サーバー一覧を読み込み
+            await loadRecorderServers();
+            
+            // モーダルを表示
+            document.getElementById('reservationModal').classList.remove('hidden');
+        }
+
+        // 予約モーダルを閉じる
+        function closeReservationModal() {
+            document.getElementById('reservationModal').classList.add('hidden');
+            currentReservationData = null;
+        }
+
+        // 録画サーバー一覧を読み込む
+        async function loadRecorderServers() {
+            const select = document.getElementById('reservationRecorderSelect');
+            
+            try {
+                const response = await fetch('/api/settings');
+                if (!response.ok) {
+                    throw new Error('設定の取得に失敗しました');
+                }
+                
+                const data = await response.json();
+                const servers = data.recorderServers || [];
+                
+                // セレクトボックスをクリア
+                select.innerHTML = '';
+                
+                if (servers.length === 0) {
+                    // デフォルトサーバーを追加
+                    const option = document.createElement('option');
+                    option.value = 'http://localhost:37569';
+                    option.textContent = 'Default Server (http://localhost:37569)';
+                    select.appendChild(option);
+                } else {
+                    // 設定されたサーバーを追加
+                    servers.forEach(server => {
+                        const option = document.createElement('option');
+                        option.value = server.url;
+                        option.textContent = `${server.name} (${server.url})`;
+                        select.appendChild(option);
+                    });
+                }
+            } catch (error) {
+                console.error('録画サーバー一覧の読み込みエラー:', error);
+                // エラー時はデフォルトサーバーを表示
+                select.innerHTML = '<option value="http://localhost:37569">Default Server (http://localhost:37569)</option>';
+            }
+        }
+
+        // 予約確定
+        function confirmReservation() {
+            if (!currentReservationData) return;
+            
+            const selectedUrl = document.getElementById('reservationRecorderSelect').value;
+            if (!selectedUrl) {
+                alert('録画サーバーを選択してください');
+                return;
+            }
+            
+            // 予約処理
+            makeReservation(currentReservationData.programId, currentReservationData.programName, selectedUrl);
+            
+            // モーダルを閉じる
+            closeReservationModal();
+        }
         
         // 予約処理
         async function makeReservation(programId, programName, recorderUrl) {
@@ -703,11 +814,52 @@
             // フィールドの表示切り替え
             toggleAutoRuleFields();
             
+            // 録画サーバー一覧を読み込み
+            await loadAutoRecorderServers();
+            
             // 番組データを保存（作成時に使用）
             window.currentProgramData = programData;
             
             // モーダルを表示
             document.getElementById('autoReservationModal').classList.remove('hidden');
+        }
+
+        // 自動予約用の録画サーバー一覧を読み込む
+        async function loadAutoRecorderServers() {
+            const select = document.getElementById('autoRecorderUrl');
+            
+            try {
+                const response = await fetch('/api/settings');
+                if (!response.ok) {
+                    throw new Error('設定の取得に失敗しました');
+                }
+                
+                const data = await response.json();
+                const servers = data.recorderServers || [];
+                
+                // セレクトボックスをクリア
+                select.innerHTML = '';
+                
+                if (servers.length === 0) {
+                    // デフォルトサーバーを追加
+                    const option = document.createElement('option');
+                    option.value = 'http://localhost:37569';
+                    option.textContent = 'Default Server (http://localhost:37569)';
+                    select.appendChild(option);
+                } else {
+                    // 設定されたサーバーを追加
+                    servers.forEach(server => {
+                        const option = document.createElement('option');
+                        option.value = server.url;
+                        option.textContent = `${server.name} (${server.url})`;
+                        select.appendChild(option);
+                    });
+                }
+            } catch (error) {
+                console.error('自動予約用録画サーバー一覧の読み込みエラー:', error);
+                // エラー時はデフォルトサーバーを表示
+                select.innerHTML = '<option value="http://localhost:37569">Default Server (http://localhost:37569)</option>';
+            }
         }
         
         // 自動予約モーダルを閉じる

--- a/static/settings.html
+++ b/static/settings.html
@@ -1,0 +1,198 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>設定 - IEPG Server</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-100 min-h-screen">
+    <div class="container mx-auto px-4 py-8">
+        <div class="mb-6">
+            <a href="/ui/search" class="text-blue-600 hover:text-blue-800">&larr; 検索に戻る</a>
+        </div>
+
+        <h1 class="text-3xl font-bold text-gray-900 mb-8">設定</h1>
+
+        <!-- Recording Server Settings -->
+        <div class="bg-white rounded-lg shadow-md p-6 mb-6">
+            <h2 class="text-xl font-semibold text-gray-900 mb-4">録画サーバー設定</h2>
+            <p class="text-gray-600 mb-4">予約時に選択できる録画サーバーを管理します。</p>
+            
+            <div id="recorderServers" class="space-y-4">
+                <!-- Server entries will be dynamically added here -->
+            </div>
+
+            <div class="mt-4 flex space-x-2">
+                <button id="addServerBtn" class="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2">
+                    サーバーを追加
+                </button>
+                <button id="saveSettingsBtn" class="px-4 py-2 bg-green-600 text-white rounded hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2">
+                    保存
+                </button>
+            </div>
+        </div>
+
+        <!-- Loading and error messages -->
+        <div id="loading" class="text-center py-4 hidden">
+            <div class="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
+            <p class="mt-2 text-gray-600">読み込み中...</p>
+        </div>
+
+        <div id="errorMessage" class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded mb-4 hidden"></div>
+        <div id="successMessage" class="bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded mb-4 hidden"></div>
+    </div>
+
+    <script>
+        let servers = [];
+        let nextId = 1;
+
+        // Load settings on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            loadSettings();
+        });
+
+        function showLoading() {
+            document.getElementById('loading').classList.remove('hidden');
+        }
+
+        function hideLoading() {
+            document.getElementById('loading').classList.add('hidden');
+        }
+
+        function showError(message) {
+            const errorDiv = document.getElementById('errorMessage');
+            errorDiv.textContent = message;
+            errorDiv.classList.remove('hidden');
+            setTimeout(() => errorDiv.classList.add('hidden'), 5000);
+        }
+
+        function showSuccess(message) {
+            const successDiv = document.getElementById('successMessage');
+            successDiv.textContent = message;
+            successDiv.classList.remove('hidden');
+            setTimeout(() => successDiv.classList.add('hidden'), 3000);
+        }
+
+        // Load settings from server
+        async function loadSettings() {
+            showLoading();
+            try {
+                const response = await fetch('/api/settings');
+                if (!response.ok) {
+                    throw new Error('設定の読み込みに失敗しました');
+                }
+                const data = await response.json();
+                servers = data.recorderServers || [];
+                if (servers.length === 0) {
+                    // Add default server if none exist
+                    servers = [{name: 'Local Server', url: 'http://localhost:37569'}];
+                }
+                renderServers();
+            } catch (error) {
+                showError(error.message);
+            } finally {
+                hideLoading();
+            }
+        }
+
+        // Render server list
+        function renderServers() {
+            const container = document.getElementById('recorderServers');
+            container.innerHTML = '';
+
+            servers.forEach((server, index) => {
+                const serverDiv = document.createElement('div');
+                serverDiv.className = 'flex items-center space-x-4 p-4 border border-gray-200 rounded-lg';
+                serverDiv.innerHTML = `
+                    <div class="flex-1">
+                        <input type="text" placeholder="サーバー名" value="${escapeHtml(server.name)}" 
+                               class="w-full px-3 py-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-blue-500"
+                               onchange="updateServer(${index}, 'name', this.value)">
+                    </div>
+                    <div class="flex-1">
+                        <input type="url" placeholder="http://localhost:37569" value="${escapeHtml(server.url)}" 
+                               class="w-full px-3 py-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-blue-500"
+                               onchange="updateServer(${index}, 'url', this.value)">
+                    </div>
+                    <button onclick="removeServer(${index})" 
+                            class="px-3 py-2 bg-red-600 text-white rounded hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2">
+                        削除
+                    </button>
+                `;
+                container.appendChild(serverDiv);
+            });
+        }
+
+        // Update server data
+        function updateServer(index, field, value) {
+            if (servers[index]) {
+                servers[index][field] = value;
+            }
+        }
+
+        // Remove server
+        function removeServer(index) {
+            if (servers.length <= 1) {
+                showError('最低1つのサーバーが必要です');
+                return;
+            }
+            servers.splice(index, 1);
+            renderServers();
+        }
+
+        // Add new server
+        document.getElementById('addServerBtn').addEventListener('click', function() {
+            servers.push({name: '', url: ''});
+            renderServers();
+        });
+
+        // Save settings
+        document.getElementById('saveSettingsBtn').addEventListener('click', async function() {
+            // Validate servers
+            for (let i = 0; i < servers.length; i++) {
+                const server = servers[i];
+                if (!server.name.trim()) {
+                    showError(`サーバー${i + 1}の名前を入力してください`);
+                    return;
+                }
+                if (!server.url.trim()) {
+                    showError(`サーバー${i + 1}のURLを入力してください`);
+                    return;
+                }
+            }
+
+            showLoading();
+            try {
+                const response = await fetch('/api/settings/recorder-servers', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                    },
+                    body: JSON.stringify({
+                        recorderServers: servers
+                    })
+                });
+
+                if (!response.ok) {
+                    const errorData = await response.text();
+                    throw new Error(errorData || '設定の保存に失敗しました');
+                }
+
+                showSuccess('設定を保存しました');
+            } catch (error) {
+                showError(error.message);
+            } finally {
+                hideLoading();
+            }
+        });
+
+        // Escape HTML to prevent XSS
+        function escapeHtml(text) {
+            const div = document.createElement('div');
+            div.textContent = text;
+            return div.innerHTML;
+        }
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## 概要
予約ボタンと自動予約ボタンで使用できる録画サーバーを事前に設定・保存できる機能を実装しました。

## 変更内容

### データベース
- `settings`テーブルを追加し、録画サーバー情報をJSON形式で保存

### バックエンド
- `models/settings.go`: 設定データ管理のモデルを追加
- `handlers/settings.go`: 設定管理用のAPIハンドラーを追加
- APIエンドポイント:
  - `GET /api/settings`: 現在の設定を取得
  - `POST /api/settings/recorder-servers`: 録画サーバー一覧を更新

### フロントエンド
- `static/settings.html`: 録画サーバーを管理できる設定画面を追加
- `static/search.html`: 
  - 予約時にプロンプトの代わりにモーダルダイアログで設定済みサーバーから選択
  - 自動予約でも同様に設定済みサーバーから選択
  - ナビゲーションに「設定」ボタンを追加

## 動作確認方法

1. アプリケーションを起動
2. 検索画面右上の「設定」ボタンをクリック
3. 録画サーバーの名前とURLを入力して「保存」
4. 検索画面で番組の「予約」または「自動予約」ボタンをクリック
5. 設定したサーバーがドロップダウンに表示されることを確認

## メリット
- 毎回URLを入力する手間が省ける
- 複数の録画サーバーを簡単に管理できる
- UIが統一され、使いやすくなる

🤖 Generated with [Claude Code](https://claude.ai/code)