### PR TITLE
fix: NHK BSがServiceMapで上書きされる問題を修正

### DIFF
--- a/db/service_fetcher.go
+++ b/db/service_fetcher.go
@@ -118,6 +118,10 @@ func StartServiceEventStream(ctx context.Context, mirakurunBaseURL string) {
 					switch event.Type {
 					case "create", "update":
 						service := convertToService(&event.Data)
+						if service.Type == 192 {
+							models.Log.Debug("ServiceEventStream: Skipping always-excluded service: %d - %s (Type=192)", service.ServiceID, service.Name)
+							continue
+						}
 						models.ServiceMapInstance.Update(service)
 						models.Log.Debug("ServiceEventStream: Updated service: %d - %s", service.ServiceID, service.Name)
 					case "remove":
@@ -189,6 +193,9 @@ func fetchServices(ctx context.Context, mirakurunBaseURL string) {
 	count := 0
 	for _, svc := range services {
 		service := convertToService(&svc)
+		if service.Type == 192 {
+			continue // Always-excluded services should not be in ServiceMap
+		}
 		models.ServiceMapInstance.Update(service)
 		count++
 	}
@@ -216,17 +223,20 @@ func convertToService(resp *mirakurunServiceResponse) *models.Service {
 		service.ChannelName = resp.Channel.Name
 		service.ChannelTSMFRel = resp.Channel.TSMFRel
 		
-		// ChannelTypeに基づいてTypeも設定（重複更新になるが整合性を確保）
+		// ChannelType based type override ONLY for non-192 services
+		// Type=192 is always-excluded (e.g. スカパー！インフォ) and must preserve original type
 		// GR=地上波=1, BS=2, CS=3
-		switch resp.Channel.Type {
-		case "GR":
-			service.Type = 1
-		case "BS":
-			service.Type = 2
-		case "CS":
-			service.Type = 3
-		default:
-			// 既存のTypeをそのまま使用
+		if resp.Type != 192 {
+			switch resp.Channel.Type {
+			case "GR":
+				service.Type = 1
+			case "BS":
+				service.Type = 2
+			case "CS":
+				service.Type = 3
+			default:
+				// 既存のTypeをそのまま使用
+			}
 		}
 	}
 	

--- a/db/service_fetcher_test.go
+++ b/db/service_fetcher_test.go
@@ -1,0 +1,142 @@
+package db
+
+import (
+	"testing"
+
+	"github.com/fuba/iepg-server/models"
+)
+
+func TestConvertToService_NormalBS(t *testing.T) {
+	// NHK BS: Type=1, ChannelType=BS -> should become Type=2
+	resp := &mirakurunServiceResponse{
+		ID:        400101,
+		ServiceID: 101,
+		NetworkID: 4,
+		Name:      "ＮＨＫ　ＢＳ",
+		Type:      1,
+		Channel: channelInfo{
+			Type:    "BS",
+			Channel: "BS15_0",
+		},
+	}
+	service := convertToService(resp)
+
+	if service.Type != 2 {
+		t.Errorf("expected Type=2 for BS channel, got %d", service.Type)
+	}
+	if service.ChannelType != "BS" {
+		t.Errorf("expected ChannelType=BS, got %s", service.ChannelType)
+	}
+	if service.ServiceID != 101 {
+		t.Errorf("expected ServiceID=101, got %d", service.ServiceID)
+	}
+}
+
+func TestConvertToService_Type192PreservesOriginalType(t *testing.T) {
+	// スカパー！インフォ: Type=192, ChannelType=CS -> should keep Type=192
+	resp := &mirakurunServiceResponse{
+		ID:        600101,
+		ServiceID: 101,
+		NetworkID: 6,
+		Name:      "スカパー！インフォ",
+		Type:      192,
+		Channel: channelInfo{
+			Type:    "CS",
+			Channel: "CS2",
+		},
+	}
+	service := convertToService(resp)
+
+	if service.Type != 192 {
+		t.Errorf("expected Type=192 to be preserved, got %d", service.Type)
+	}
+}
+
+func TestConvertToService_NormalGR(t *testing.T) {
+	resp := &mirakurunServiceResponse{
+		ID:        3273601024,
+		ServiceID: 1024,
+		NetworkID: 32736,
+		Name:      "ＮＨＫ総合",
+		Type:      1,
+		Channel: channelInfo{
+			Type:    "GR",
+			Channel: "27",
+		},
+	}
+	service := convertToService(resp)
+
+	if service.Type != 1 {
+		t.Errorf("expected Type=1 for GR channel, got %d", service.Type)
+	}
+}
+
+func TestConvertToService_NormalCS(t *testing.T) {
+	resp := &mirakurunServiceResponse{
+		ID:        700296,
+		ServiceID: 296,
+		NetworkID: 7,
+		Name:      "TBSチャンネル1",
+		Type:      1,
+		Channel: channelInfo{
+			Type:    "CS",
+			Channel: "CS4",
+		},
+	}
+	service := convertToService(resp)
+
+	if service.Type != 3 {
+		t.Errorf("expected Type=3 for CS channel, got %d", service.Type)
+	}
+}
+
+func TestServiceMapNotOverwrittenByType192(t *testing.T) {
+	// Simulate the scenario where NHK BS and スカパー！インフォ share serviceId=101
+	sm := models.NewServiceMap()
+
+	// First: NHK BS (Type=1, ChannelType=BS)
+	nhkBS := &mirakurunServiceResponse{
+		ID:        400101,
+		ServiceID: 101,
+		NetworkID: 4,
+		Name:      "ＮＨＫ　ＢＳ",
+		Type:      1,
+		Channel: channelInfo{
+			Type:    "BS",
+			Channel: "BS15_0",
+		},
+	}
+	svc := convertToService(nhkBS)
+	if svc.Type != 192 {
+		sm.Update(svc)
+	}
+
+	// Second: スカパー！インフォ (Type=192, ChannelType=CS)
+	skyper := &mirakurunServiceResponse{
+		ID:        600101,
+		ServiceID: 101,
+		NetworkID: 6,
+		Name:      "スカパー！インフォ",
+		Type:      192,
+		Channel: channelInfo{
+			Type:    "CS",
+			Channel: "CS2",
+		},
+	}
+	svc2 := convertToService(skyper)
+	if svc2.Type != 192 {
+		sm.Update(svc2)
+	}
+
+	// Verify NHK BS is still in the map, not overwritten by スカパー！インフォ
+	result, ok := sm.Get(101)
+	if !ok {
+		t.Fatal("expected service 101 to be in the map")
+	}
+	if result.Name != "ＮＨＫ　ＢＳ" {
+		t.Errorf("expected Name=ＮＨＫ　ＢＳ, got %s", result.Name)
+	}
+	if result.Type != 2 {
+		t.Errorf("expected Type=2 (BS), got %d", result.Type)
+	}
+}


### PR DESCRIPTION
## Summary
- MirakurunのサービスAPIで `serviceId=101` を持つサービスが2つ（NHK BS と スカパー！インフォ）存在し、後者がServiceMapで前者を上書きしていた問題を修正
- `convertToService()` で Type=192 のサービスの ChannelType ベースの Type 上書きをスキップするよう変更
- `fetchServices()` と `StartServiceEventStream()` で Type=192 のサービスを ServiceMap に登録しないよう変更

## Changes
1. **`convertToService()`**: Type=192 のサービスは ChannelType に基づく Type 上書きをスキップし、元の Type=192 を保持
2. **`fetchServices()`**: Type=192 のサービスは ServiceMap への登録をスキップ
3. **`StartServiceEventStream()`**: イベントストリームでも Type=192 のサービスの ServiceMap 更新をスキップ
4. **テスト追加**: `service_fetcher_test.go` に変換ロジックとServiceMap上書き防止のテストを追加

## Test plan
- [x] `go build ./...` でビルドが通ること
- [x] `go test ./db/` で新規テスト含む全テストがパス
- [ ] docker compose でデプロイ後、`GET /services/all` で serviceId=101 が NHK BS として表示されること
- [ ] `GET /search?channelType=2` で NHK BS の番組が含まれること

🤖 Generated with [Claude Code](https://claude.com/claude-code)