### PR TITLE
Add /health endpoint and fix broken healthcheck

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       - ENABLE_CLEANUP=true
       - SKIP_INITIAL_LOAD=false
     healthcheck:
-      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:40870/services", "||", "exit", "1"]
+      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:40870/health"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/main.go
+++ b/main.go
@@ -127,6 +127,12 @@ func main() {
 	// ルーターの設定
 	router := mux.NewRouter()
 
+	// Health check endpoint
+	router.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("ok"))
+	})
+
 	// HTTPエンドポイントの設定
 	router.HandleFunc("/search", func(w http.ResponseWriter, r *http.Request) {
 		models.Log.Debug("Handling search request: %s", r.URL.String())


### PR DESCRIPTION
## Summary
- healthcheck が `["CMD", "wget", ..., "||", "exit", "1"]` という CMD array 形式で、`||` がシェル解釈されず wget のURL引数として渡されていた（FailingStreak: 64,807）
- `/health` エンドポイントを追加し、healthcheck をシンプルな形式に修正

## Test plan
- [ ] `docker compose up --build -d` で起動
- [ ] `curl http://localhost:40870/health` → 200 ok
- [ ] `docker inspect iepg-server` で healthcheck が healthy になること

🤖 Generated with [Claude Code](https://claude.com/claude-code)