### PR TITLE
feat: networkIdをServiceMap/Program/DB全体で扱う + Mirakurun接続先修正

### DIFF
--- a/db/database.go
+++ b/db/database.go
@@ -18,6 +18,32 @@ import (
 	"github.com/fuba/iepg-server/models"
 )
 
+// hasColumn は指定テーブルに指定カラムが存在するかを PRAGMA table_info で判定する。
+func hasColumn(db *sql.DB, table, column string) (bool, error) {
+	rows, err := db.Query("PRAGMA table_info(" + table + ")")
+	if err != nil {
+		return false, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var (
+			cid     int
+			name    string
+			ctype   string
+			notnull int
+			dflt    sql.NullString
+			pk      int
+		)
+		if err := rows.Scan(&cid, &name, &ctype, &notnull, &dflt, &pk); err != nil {
+			return false, err
+		}
+		if name == column {
+			return true, nil
+		}
+	}
+	return false, rows.Err()
+}
+
 // InitDB は、programsテーブルと除外チャンネルテーブルを作成する。
 func InitDB(dataSourceName string) (*sql.DB, error) {
 	models.Log.Debug("InitDB: Connecting to database: %s", dataSourceName)
@@ -41,6 +67,7 @@ func InitDB(dataSourceName string) (*sql.DB, error) {
 		CREATE TABLE IF NOT EXISTS programs (
 			id            INTEGER PRIMARY KEY,
 			serviceId     INTEGER,
+			networkId     INTEGER DEFAULT 0,
 			startAt       INTEGER,
 			duration      INTEGER,
 			name          TEXT,
@@ -60,6 +87,43 @@ func InitDB(dataSourceName string) (*sql.DB, error) {
 		models.Log.Error("InitDB: Failed to create programs table: %v", err)
 		db.Close()
 		return nil, err
+	}
+
+	// 既存 DB 向けマイグレーション: networkId カラムが無ければ追加
+	hasNetworkID, err := hasColumn(db, "programs", "networkId")
+	if err != nil {
+		models.Log.Error("InitDB: Failed to inspect programs columns: %v", err)
+		db.Close()
+		return nil, err
+	}
+	if !hasNetworkID {
+		if _, err := db.Exec(`ALTER TABLE programs ADD COLUMN networkId INTEGER DEFAULT 0`); err != nil {
+			models.Log.Error("InitDB: Failed to add networkId column: %v", err)
+			db.Close()
+			return nil, err
+		}
+		models.Log.Info("InitDB: Added networkId column to programs table")
+	}
+
+	// 既存行の networkId=0 を Mirakurun program ID から逆算してバックフィル。
+	// Mirakurun は id = networkId*10^10 + serviceId*10^5 + eventId で構成するため、
+	// 桁構成と (id/10^5)%10^5 == serviceId で整合が取れるものだけ更新する。
+	res, err := db.Exec(`
+		UPDATE programs
+		SET networkId = id / 10000000000
+		WHERE networkId = 0
+		  AND id >= 10000000000
+		  AND (id / 100000) % 100000 = serviceId
+	`)
+	if err != nil {
+		models.Log.Error("InitDB: Failed to backfill networkId: %v", err)
+	} else if n, _ := res.RowsAffected(); n > 0 {
+		models.Log.Info("InitDB: Backfilled networkId for %d programs", n)
+	}
+
+	// networkId を含むインデックス
+	if _, err := db.Exec(`CREATE INDEX IF NOT EXISTS idx_programs_networkId_serviceId ON programs(networkId, serviceId)`); err != nil {
+		models.Log.Error("InitDB: Failed to create networkId_serviceId index: %v", err)
 	}
 
 	// 除外チャンネルテーブルの作成
@@ -346,10 +410,10 @@ func StartStreamFetcher(ctx context.Context, db *sql.DB, apiURL string) {
 						
 						_, err = db.Exec(`
 							INSERT OR REPLACE INTO programs
-								(id, serviceId, startAt, duration, name, description, nameForSearch, descForSearch,
+								(id, serviceId, networkId, startAt, duration, name, description, nameForSearch, descForSearch,
 								 seriesId, seriesEpisode, seriesLastEpisode, seriesName, seriesRepeat, seriesPattern, seriesExpiresAt)
-							VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
-						`, p.ID, p.ServiceID, p.StartAt, p.Duration, p.Name, p.Description, p.NameForSearch, p.DescForSearch,
+							VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+						`, p.ID, p.ServiceID, p.NetworkID, p.StartAt, p.Duration, p.Name, p.Description, p.NameForSearch, p.DescForSearch,
 						   seriesId, seriesEpisode, seriesLastEpisode, seriesName, seriesRepeat, seriesPattern, seriesExpiresAt)
 
 						if err != nil {
@@ -546,7 +610,7 @@ func SearchPrograms(db *sql.DB, q string, serviceId, startFrom, startTo int64, c
 
 		// クエリの基本部分を構築
 		query = `
-			SELECT id, serviceId, startAt, duration, name, description,
+			SELECT id, serviceId, networkId, startAt, duration, name, description,
 				   seriesId, seriesEpisode, seriesLastEpisode, seriesName, seriesRepeat, seriesPattern, seriesExpiresAt
 			FROM programs
 			WHERE 1=1
@@ -602,7 +666,7 @@ func SearchPrograms(db *sql.DB, q string, serviceId, startFrom, startTo int64, c
 		models.Log.Debug("SearchPrograms: Added negative search conditions: %v", negativeTerms)
 		models.Log.Debug("SearchPrograms: Query after all search conditions: %s", query)
 	} else {
-		query = `SELECT id, serviceId, startAt, duration, name, description,
+		query = `SELECT id, serviceId, networkId, startAt, duration, name, description,
 				 seriesId, seriesEpisode, seriesLastEpisode, seriesName, seriesRepeat, seriesPattern, seriesExpiresAt
 				 FROM programs`
 		models.Log.Debug("SearchPrograms: Using regular query without search terms")
@@ -722,7 +786,7 @@ func SearchPrograms(db *sql.DB, q string, serviceId, startFrom, startTo int64, c
 		var seriesName sql.NullString
 		var seriesExpiresAt sql.NullInt64
 		
-		if err := rows.Scan(&p.ID, &p.ServiceID, &p.StartAt, &p.Duration, &p.Name, &p.Description,
+		if err := rows.Scan(&p.ID, &p.ServiceID, &p.NetworkID, &p.StartAt, &p.Duration, &p.Name, &p.Description,
 			&seriesId, &seriesEpisode, &seriesLastEpisode, &seriesName, &seriesRepeat, &seriesPattern, &seriesExpiresAt); err != nil {
 			models.Log.Error("SearchPrograms: Scan error: %v", err)
 			return nil, err
@@ -760,10 +824,10 @@ func GetProgramByID(db *sql.DB, id int64) (*models.Program, error) {
 	var seriesName sql.NullString
 	var seriesExpiresAt sql.NullInt64
 	
-	err := db.QueryRow(`SELECT id, serviceId, startAt, duration, name, description,
-						seriesId, seriesEpisode, seriesLastEpisode, seriesName, seriesRepeat, seriesPattern, seriesExpiresAt 
+	err := db.QueryRow(`SELECT id, serviceId, networkId, startAt, duration, name, description,
+						seriesId, seriesEpisode, seriesLastEpisode, seriesName, seriesRepeat, seriesPattern, seriesExpiresAt
 						FROM programs WHERE id = ?`, id).
-		Scan(&p.ID, &p.ServiceID, &p.StartAt, &p.Duration, &p.Name, &p.Description,
+		Scan(&p.ID, &p.ServiceID, &p.NetworkID, &p.StartAt, &p.Duration, &p.Name, &p.Description,
 			 &seriesId, &seriesEpisode, &seriesLastEpisode, &seriesName, &seriesRepeat, &seriesPattern, &seriesExpiresAt)
 
 	if err != nil {
@@ -894,8 +958,10 @@ func GetExcludedServices(db *sql.DB) ([]models.ExcludedService, error) {
 			return nil, err
 		}
 		
-		// サービスマップから追加情報を取得
-		if service, ok := models.ServiceMapInstance.Get(s.ServiceID); ok {
+		// サービスマップから追加情報を取得 (excluded_services は serviceId のみ保持なので GetByServiceID を使用)
+		candidates := models.ServiceMapInstance.GetByServiceID(s.ServiceID)
+		if len(candidates) > 0 {
+			service := candidates[0]
 			s.Type = service.Type
 			s.NetworkID = service.NetworkID
 			s.RemoteControlKeyID = service.RemoteControlKeyID
@@ -1044,9 +1110,9 @@ func InitProgramsFromAPI(ctx context.Context, db *sql.DB, mirakurunBaseURL strin
 
 	// バッチインサートのためのステートメント準備
 	stmtPrograms, err := tx.Prepare(`
-		INSERT INTO programs (id, serviceId, startAt, duration, name, description, nameForSearch, descForSearch,
+		INSERT INTO programs (id, serviceId, networkId, startAt, duration, name, description, nameForSearch, descForSearch,
 							  seriesId, seriesEpisode, seriesLastEpisode, seriesName, seriesRepeat, seriesPattern, seriesExpiresAt)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
 	`)
 	if err != nil {
 		tx.Rollback()
@@ -1076,7 +1142,7 @@ func InitProgramsFromAPI(ctx context.Context, db *sql.DB, mirakurunBaseURL strin
 			seriesExpiresAt = p.Series.ExpiresAt
 		}
 		
-		_, err = stmtPrograms.Exec(p.ID, p.ServiceID, p.StartAt, p.Duration, p.Name, p.Description, p.NameForSearch, p.DescForSearch,
+		_, err = stmtPrograms.Exec(p.ID, p.ServiceID, p.NetworkID, p.StartAt, p.Duration, p.Name, p.Description, p.NameForSearch, p.DescForSearch,
 								  seriesId, seriesEpisode, seriesLastEpisode, seriesName, seriesRepeat, seriesPattern, seriesExpiresAt)
 		if err != nil {
 			tx.Rollback()

--- a/db/migration_test.go
+++ b/db/migration_test.go
@@ -1,0 +1,146 @@
+package db
+
+import (
+	"database/sql"
+	"testing"
+
+	"github.com/fuba/iepg-server/models"
+	_ "github.com/mattn/go-sqlite3"
+)
+
+// legacySchema re-creates the pre-migration programs table (no networkId column)
+// so we can validate the ALTER TABLE + backfill path.
+const legacySchema = `
+CREATE TABLE programs (
+	id            INTEGER PRIMARY KEY,
+	serviceId     INTEGER,
+	startAt       INTEGER,
+	duration      INTEGER,
+	name          TEXT,
+	description   TEXT,
+	nameForSearch TEXT,
+	descForSearch TEXT,
+	seriesId      INTEGER,
+	seriesEpisode INTEGER,
+	seriesLastEpisode INTEGER,
+	seriesName    TEXT,
+	seriesRepeat  INTEGER,
+	seriesPattern INTEGER,
+	seriesExpiresAt INTEGER
+);
+`
+
+// seedLegacyRow inserts a row that pre-dates the networkId migration.
+func seedLegacyRow(t *testing.T, db *sql.DB, id, serviceId int64) {
+	t.Helper()
+	if _, err := db.Exec(`INSERT INTO programs (id, serviceId, startAt, duration, name) VALUES (?, ?, 0, 0, '')`, id, serviceId); err != nil {
+		t.Fatalf("seed id=%d: %v", id, err)
+	}
+}
+
+func TestMigration_BackfillNetworkID(t *testing.T) {
+	path := t.TempDir() + "/legacy.db"
+	raw, err := sql.Open("sqlite3", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := raw.Exec(legacySchema); err != nil {
+		t.Fatalf("create legacy schema: %v", err)
+	}
+
+	// Mirakurun format: id = networkId * 10^10 + serviceId * 10^5 + eventId
+	mkID := func(net, svc, ev int64) int64 { return net*10000000000 + svc*100000 + ev }
+
+	// Well-formed Mirakurun rows (should be backfilled)
+	seedLegacyRow(t, raw, mkID(32742, 1072, 51879), 1072) // テレ東
+	seedLegacyRow(t, raw, mkID(7, 312, 63155), 312)       // CS
+
+	// Malformed row: id big enough but serviceId doesn't match encoded id (should NOT be backfilled)
+	seedLegacyRow(t, raw, mkID(32742, 1072, 1), 999)
+
+	// Small id (< 10^10): legacy fake id (should NOT be backfilled)
+	seedLegacyRow(t, raw, 12345, 101)
+	raw.Close()
+
+	// Now run InitDB against the same file — it must migrate + backfill safely.
+	db, err := InitDB(path)
+	if err != nil {
+		t.Fatalf("InitDB: %v", err)
+	}
+	defer db.Close()
+
+	cases := []struct {
+		id   int64
+		want int64
+	}{
+		{mkID(32742, 1072, 51879), 32742},
+		{mkID(7, 312, 63155), 7},
+		{mkID(32742, 1072, 1), 0}, // serviceId mismatch → not backfilled
+		{12345, 0},                // too small → not backfilled
+	}
+	for _, c := range cases {
+		var got int64
+		if err := db.QueryRow("SELECT networkId FROM programs WHERE id = ?", c.id).Scan(&got); err != nil {
+			t.Fatalf("query id=%d: %v", c.id, err)
+		}
+		if got != c.want {
+			t.Errorf("id=%d networkId=%d want %d", c.id, got, c.want)
+		}
+	}
+}
+
+func TestMigration_IsIdempotent(t *testing.T) {
+	path := t.TempDir() + "/idem.db"
+
+	// Run InitDB twice — neither call should error.
+	db1, err := InitDB(path)
+	if err != nil {
+		t.Fatalf("first InitDB: %v", err)
+	}
+	db1.Close()
+
+	db2, err := InitDB(path)
+	if err != nil {
+		t.Fatalf("second InitDB: %v", err)
+	}
+	defer db2.Close()
+
+	ok, err := hasColumn(db2, "programs", "networkId")
+	if err != nil || !ok {
+		t.Fatalf("networkId column missing after idempotent init: ok=%v err=%v", ok, err)
+	}
+}
+
+func TestSearchProgramsScansNetworkID(t *testing.T) {
+	db, err := InitDB(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	// Insert with networkId explicitly set via new INSERT path.
+	if _, err := db.Exec(`INSERT INTO programs (id, serviceId, networkId, startAt, duration, name, description, nameForSearch, descForSearch, seriesId, seriesEpisode, seriesLastEpisode, seriesName, seriesRepeat, seriesPattern, seriesExpiresAt)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		327420107251879, 1072, 32742, 1, 1, "x", "", models.NormalizeForSearch("x"), "", nil, nil, nil, nil, nil, nil, nil); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	programs, err := SearchPrograms(db, "", 1072, 0, 0, 0)
+	if err != nil {
+		t.Fatalf("SearchPrograms: %v", err)
+	}
+	if len(programs) != 1 {
+		t.Fatalf("got %d programs, want 1", len(programs))
+	}
+	if programs[0].NetworkID != 32742 {
+		t.Errorf("NetworkID=%d want 32742", programs[0].NetworkID)
+	}
+
+	got, err := GetProgramByID(db, 327420107251879)
+	if err != nil {
+		t.Fatalf("GetProgramByID: %v", err)
+	}
+	if got.NetworkID != 32742 {
+		t.Errorf("GetProgramByID NetworkID=%d want 32742", got.NetworkID)
+	}
+}

--- a/db/service_fetcher.go
+++ b/db/service_fetcher.go
@@ -121,8 +121,22 @@ func StartServiceEventStream(ctx context.Context, mirakurunBaseURL string) {
 						models.ServiceMapInstance.Update(service)
 						models.Log.Debug("ServiceEventStream: Updated service: %d - %s", service.ServiceID, service.Name)
 					case "remove":
-						models.ServiceMapInstance.Remove(event.Data.ServiceID)
-						models.Log.Debug("ServiceEventStream: Removed service: %d", event.Data.ServiceID)
+						// Mirakurun remove イベントは基本的に `id` (Mirakurun unique ID) を含むが、
+						// 古い/欠損ペイロードに備えて優先順位でフォールバックする。
+						switch {
+						case event.Data.ID != 0:
+							models.ServiceMapInstance.Remove(event.Data.ID)
+							models.Log.Debug("ServiceEventStream: Removed service by mirakurunID=%d", event.Data.ID)
+						case event.Data.NetworkID != 0:
+							id := models.MirakurunID(event.Data.NetworkID, event.Data.ServiceID)
+							models.ServiceMapInstance.Remove(id)
+							models.Log.Debug("ServiceEventStream: Removed service by composed mirakurunID=%d (networkID=%d, serviceID=%d)",
+								id, event.Data.NetworkID, event.Data.ServiceID)
+						default:
+							n := models.ServiceMapInstance.RemoveByServiceID(event.Data.ServiceID)
+							models.Log.Debug("ServiceEventStream: Removed %d service(s) by serviceID=%d (fallback)",
+								n, event.Data.ServiceID)
+						}
 					}
 				}
 			}

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -6,7 +6,6 @@ services:
   iepg-server:
     environment:
       - LOG_LEVEL=debug
-      - SKIP_INITIAL_LOAD=true  # 開発環境では初期ロードをスキップ
     volumes:
       # 開発時は静的ファイルもマウント
       - ./static:/app/static

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - PORT=40870
       - LOG_LEVEL=info
       - DB_PATH=/app/data/programs.db
-      - MIRAKURUN_URL=http://localhost:40772/api
+      - MIRAKURUN_URL=http://tuner:40772/api
       - RECORDER_URL=http://localhost:37569
       - ENABLE_AUTO_RESERVATION=true
       - ENABLE_CLEANUP=true

--- a/handlers/iepg.go
+++ b/handlers/iepg.go
@@ -67,7 +67,15 @@ func HandleIEPG(w http.ResponseWriter, r *http.Request, dbConn *sql.DB) {
 	// 番組に対応するサービス（テレビ局）情報を取得
 	var stationId, stationName, channelType, channelNumber string
 	var serviceId int64
-	if service, ok := models.ServiceMapInstance.Get(p.ServiceID); ok {
+	mirakurunID := models.MirakurunID(p.NetworkID, p.ServiceID)
+	service, ok := models.ServiceMapInstance.Get(mirakurunID)
+	if !ok {
+		if candidates := models.ServiceMapInstance.GetByServiceID(p.ServiceID); len(candidates) > 0 {
+			service = candidates[0]
+			ok = true
+		}
+	}
+	if ok {
 		// リモコンキーIDあるいはサービスIDを文字列に変換
 		if service.RemoteControlKeyID > 0 {
 			stationId = fmt.Sprintf("%04d", service.RemoteControlKeyID)

--- a/handlers/search.go
+++ b/handlers/search.go
@@ -92,8 +92,16 @@ func HandleSimpleSearch(w http.ResponseWriter, r *http.Request, dbConn *sql.DB) 
 		programs[i].Name = normalizeSpecialCharacters(programs[i].Name)
 		programs[i].Description = normalizeSpecialCharacters(programs[i].Description)
 		
-		// サービス情報を付与
-		if service, ok := models.ServiceMapInstance.Get(programs[i].ServiceID); ok {
+		// サービス情報を付与 (Mirakurun ID で引く; networkID が 0 なら serviceID のみで一致する先頭要素)
+		mirakurunID := models.MirakurunID(programs[i].NetworkID, programs[i].ServiceID)
+		service, ok := models.ServiceMapInstance.Get(mirakurunID)
+		if !ok {
+			if candidates := models.ServiceMapInstance.GetByServiceID(programs[i].ServiceID); len(candidates) > 0 {
+				service = candidates[0]
+				ok = true
+			}
+		}
+		if ok {
 			// テレビ局情報を付与
 			programs[i].StationName = service.Name
 			
@@ -343,8 +351,8 @@ func HandleAddExcludedService(w http.ResponseWriter, r *http.Request, dbConn *sq
 	
 	// サービス名が空の場合、ServiceMapから名前を取得
 	if service.Name == "" {
-		if svc, ok := models.ServiceMapInstance.Get(service.ServiceID); ok {
-			service.Name = svc.Name
+		if candidates := models.ServiceMapInstance.GetByServiceID(service.ServiceID); len(candidates) > 0 {
+			service.Name = candidates[0].Name
 			models.Log.Debug("HandleAddExcludedService: Found service name from ServiceMap: %s", service.Name)
 		} else {
 			service.Name = fmt.Sprintf("Service %d", service.ServiceID)

--- a/models/program.go
+++ b/models/program.go
@@ -16,6 +16,7 @@ type Series struct {
 type Program struct {
 	ID                int64  `json:"id"`
 	ServiceID         int64  `json:"serviceId"`
+	NetworkID         int64  `json:"networkId"`
 	StartAt           int64  `json:"startAt"`
 	Duration          int64  `json:"duration"`
 	Name              string `json:"name"`

--- a/models/service.go
+++ b/models/service.go
@@ -2,8 +2,15 @@
 package models
 
 import (
+	"sort"
 	"sync"
 )
+
+// MirakurunID composes the Mirakurun unique ID from networkID and serviceID.
+// Matches Mirakurun's encoding: id = networkID * 100000 + serviceID.
+func MirakurunID(networkID, serviceID int64) int64 {
+	return networkID*100000 + serviceID
+}
 
 // Service はMirakurunから取得するサービス情報（テレビ局情報）の構造体
 type Service struct {
@@ -34,10 +41,11 @@ type ChannelInfo struct {
 	TSMFRel int    `json:"tsmfRelTs,omitempty"`
 }
 
-// ServiceMap はサービスIDをキーとしてServiceの参照を保持するマップ
+// ServiceMap は Mirakurun ID (service.ID = networkID*100000+serviceID) をキーとして
+// Service の参照を保持するマップ。同じ serviceID でも networkID が異なれば別要素として扱う。
 type ServiceMap struct {
 	mu       sync.RWMutex
-	services map[int64]*Service // サービスIDをキーにしたマップ
+	services map[int64]*Service // Mirakurun ID (service.ID) をキーにしたマップ
 }
 
 // NewServiceMap は新しいServiceMapを作成する
@@ -51,29 +59,60 @@ func NewServiceMap() *ServiceMap {
 func (sm *ServiceMap) Add(service *Service) {
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
-	sm.services[service.ServiceID] = service
+	sm.services[service.ID] = service
 }
 
 // Update はサービス情報を更新する
 func (sm *ServiceMap) Update(service *Service) {
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
-	sm.services[service.ServiceID] = service
+	sm.services[service.ID] = service
 }
 
-// Remove はサービス情報を削除する
-func (sm *ServiceMap) Remove(serviceID int64) {
+// Remove は Mirakurun ID でサービス情報を削除する
+func (sm *ServiceMap) Remove(mirakurunID int64) {
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
-	delete(sm.services, serviceID)
+	delete(sm.services, mirakurunID)
 }
 
-// Get はサービスIDからサービス情報を取得する
-func (sm *ServiceMap) Get(serviceID int64) (*Service, bool) {
+// Get は Mirakurun ID からサービス情報を取得する
+func (sm *ServiceMap) Get(mirakurunID int64) (*Service, bool) {
 	sm.mu.RLock()
 	defer sm.mu.RUnlock()
-	service, ok := sm.services[serviceID]
+	service, ok := sm.services[mirakurunID]
 	return service, ok
+}
+
+// GetByServiceID は serviceID に一致するすべての Service を、
+// Mirakurun ID (service.ID) 昇順で決定的に返す。
+// networkID 情報が無い文脈（excluded_services 等）からの後方互換用。
+func (sm *ServiceMap) GetByServiceID(serviceID int64) []*Service {
+	sm.mu.RLock()
+	defer sm.mu.RUnlock()
+	var result []*Service
+	for _, s := range sm.services {
+		if s.ServiceID == serviceID {
+			result = append(result, s)
+		}
+	}
+	sort.Slice(result, func(i, j int) bool { return result[i].ID < result[j].ID })
+	return result
+}
+
+// RemoveByServiceID は serviceID に一致するすべての Service を削除する。
+// Mirakurun ID が判らない remove イベントのフォールバック用。
+func (sm *ServiceMap) RemoveByServiceID(serviceID int64) int {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+	removed := 0
+	for id, s := range sm.services {
+		if s.ServiceID == serviceID {
+			delete(sm.services, id)
+			removed++
+		}
+	}
+	return removed
 }
 
 // GetAll はすべてのサービス情報を取得する

--- a/models/service_test.go
+++ b/models/service_test.go
@@ -1,0 +1,122 @@
+package models
+
+import "testing"
+
+func TestMirakurunID(t *testing.T) {
+	cases := []struct {
+		name      string
+		networkID int64
+		serviceID int64
+		want      int64
+	}{
+		{"terrestrial TV Tokyo", 32742, 1072, 3274201072},
+		{"BS NHK1", 4, 101, 400101},
+		{"CS channel", 7, 300, 700300},
+		{"zero network", 0, 1234, 1234},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := MirakurunID(c.networkID, c.serviceID)
+			if got != c.want {
+				t.Errorf("MirakurunID(%d, %d) = %d, want %d", c.networkID, c.serviceID, got, c.want)
+			}
+		})
+	}
+}
+
+func TestServiceMapKeyedByMirakurunID(t *testing.T) {
+	sm := NewServiceMap()
+
+	// Two services sharing serviceID across different networks
+	a := &Service{ID: MirakurunID(32742, 1072), ServiceID: 1072, NetworkID: 32742, Name: "テレ東"}
+	b := &Service{ID: MirakurunID(32736, 1072), ServiceID: 1072, NetworkID: 32736, Name: "BS something"}
+
+	sm.Add(a)
+	sm.Add(b)
+
+	gotA, ok := sm.Get(a.ID)
+	if !ok || gotA.Name != "テレ東" {
+		t.Errorf("Get(%d) = %+v, ok=%v; want テレ東", a.ID, gotA, ok)
+	}
+	gotB, ok := sm.Get(b.ID)
+	if !ok || gotB.Name != "BS something" {
+		t.Errorf("Get(%d) = %+v, ok=%v; want BS something", b.ID, gotB, ok)
+	}
+
+	all := sm.GetByServiceID(1072)
+	if len(all) != 2 {
+		t.Fatalf("GetByServiceID(1072) len=%d, want 2", len(all))
+	}
+}
+
+func TestGetByServiceIDIsDeterministic(t *testing.T) {
+	// Register services in a semi-random order and confirm returned order is
+	// always service.ID ascending regardless of insertion order.
+	networkIDs := []int64{32742, 32736, 4, 32740, 7, 100, 32738}
+	serviceID := int64(1072)
+	sm := NewServiceMap()
+	for _, n := range networkIDs {
+		sm.Add(&Service{ID: MirakurunID(n, serviceID), ServiceID: serviceID, NetworkID: n})
+	}
+	want := []int64{
+		MirakurunID(4, serviceID),
+		MirakurunID(7, serviceID),
+		MirakurunID(100, serviceID),
+		MirakurunID(32736, serviceID),
+		MirakurunID(32738, serviceID),
+		MirakurunID(32740, serviceID),
+		MirakurunID(32742, serviceID),
+	}
+	// sanity: want must be sorted ascending
+	for i := 1; i < len(want); i++ {
+		if want[i-1] >= want[i] {
+			t.Fatalf("want slice not sorted: %v", want)
+		}
+	}
+
+	for i := 0; i < 5; i++ {
+		got := sm.GetByServiceID(serviceID)
+		if len(got) != len(want) {
+			t.Fatalf("GetByServiceID len=%d want=%d", len(got), len(want))
+		}
+		for j, s := range got {
+			if s.ID != want[j] {
+				t.Errorf("iter %d pos %d: got ID=%d want %d", i, j, s.ID, want[j])
+			}
+		}
+	}
+}
+
+func TestRemoveByServiceID(t *testing.T) {
+	sm := NewServiceMap()
+	sm.Add(&Service{ID: MirakurunID(32742, 1072), ServiceID: 1072, NetworkID: 32742, Name: "テレ東"})
+	sm.Add(&Service{ID: MirakurunID(32736, 1072), ServiceID: 1072, NetworkID: 32736, Name: "BS dup"})
+	sm.Add(&Service{ID: MirakurunID(32736, 101), ServiceID: 101, NetworkID: 32736, Name: "BS NHK1"})
+
+	n := sm.RemoveByServiceID(1072)
+	if n != 2 {
+		t.Errorf("RemoveByServiceID(1072) removed %d, want 2", n)
+	}
+	if got := sm.GetByServiceID(1072); len(got) != 0 {
+		t.Errorf("after RemoveByServiceID(1072): len=%d want 0", len(got))
+	}
+	if got := sm.GetByServiceID(101); len(got) != 1 {
+		t.Errorf("unrelated service removed: len=%d want 1", len(got))
+	}
+}
+
+func TestServiceMapRemoveByMirakurunID(t *testing.T) {
+	sm := NewServiceMap()
+	a := &Service{ID: MirakurunID(32742, 1072), ServiceID: 1072, NetworkID: 32742, Name: "テレ東"}
+	b := &Service{ID: MirakurunID(32736, 1072), ServiceID: 1072, NetworkID: 32736, Name: "BS"}
+	sm.Add(a)
+	sm.Add(b)
+
+	sm.Remove(a.ID)
+	if _, ok := sm.Get(a.ID); ok {
+		t.Errorf("Get(%d) after Remove: still present", a.ID)
+	}
+	if _, ok := sm.Get(b.ID); !ok {
+		t.Errorf("Get(%d) after Remove of a: b disappeared", b.ID)
+	}
+}


### PR DESCRIPTION
## Summary
- iepg-serverからMirakurunへのストリーム接続が404ループしていた原因を修正し、接続先をLAN上の`tuner`ホストに切り替え。開発用の`SKIP_INITIAL_LOAD=true`オーバーライドも削除
- memory.mdに書かれていた設計意図「ServiceMapはMirakurun unique ID (networkId*100000+serviceId) でキーする」「ProgramにNetworkIDを持つ」に実コードを追従させ、これまでDBに書かれていなかった`networkId`列を全INSERT/SELECTで正しく扱うように

## 主要変更

### 接続修正
- `docker-compose.yml`: `MIRAKURUN_URL=http://tuner:40772/api`
- `docker-compose.override.yml`: `SKIP_INITIAL_LOAD=true`を削除

### networkId対応
- `models.MirakurunID(networkID, serviceID)` helper新設
- `models.Program.NetworkID`追加
- `ServiceMap`を`service.ID`キーに再編し、`GetByServiceID(serviceID) []*Service`（service.ID昇順で決定的）と`RemoveByServiceID(serviceID)`を追加
- `db/database.go`のマイグレーション:
  - `PRAGMA table_info`で`networkId`列の有無を判定してから`ALTER TABLE`（べき等）
  - `(id/100000)%100000 = serviceId`でMirakurun形式に限定して`id/10^10`からバックフィル
  - `(networkId, serviceId)`複合インデックス作成
- `InitProgramsFromAPI`と`StreamFetcher`のINSERT、`SearchPrograms`/`GetProgramByID`のSELECTに`networkId`を反映
- `ServiceEventStream`のremoveは`event.Data.ID`→合成→`RemoveByServiceID`の3段フォールバック
- `handlers/search.go`・`handlers/iepg.go`・`db/database.go`でServiceMapルックアップを`MirakurunID(p.NetworkID, p.ServiceID)`経由に変更。networkIdが無いexcluded_services文脈は`GetByServiceID`の決定的先頭要素を採用

### テスト
- `models/service_test.go`: `MirakurunID`、ServiceMapのMirakurun IDキーイング、`GetByServiceID`の決定性、`RemoveByServiceID`
- `db/migration_test.go`: バックフィル条件（正常/不一致/小ID）、idempotent起動、SELECT時のnetworkId Scan

## 検証結果

- `go test ./...` 全通過（既知のサーバー必須な`TestRealServiceExcludeUnexclude`のみスキップ）
- Dockerで再起動後、DB 22295件中`networkId=0`は0件
- `/search?serviceId=1072` → テレ東312件全件に`networkId=32742`紐付け

## Test plan
- [x] go test ./...
- [x] docker compose build + up でバックフィル完走
- [x] /search?serviceId=1072 でテレ東の番組が取れる
- [x] /health = ok
- [x] ストリーム404ループが解消しprogramsが流入している

🤖 Generated with [Claude Code](https://claude.com/claude-code)